### PR TITLE
chore: Updates Inngest client to 1.3.5

### DIFF
--- a/.changeset/real-lions-tease.md
+++ b/.changeset/real-lions-tease.md
@@ -1,0 +1,5 @@
+---
+'envelop-plugin-inngest': minor
+---
+
+Updates Inngest client to 1.3.5

--- a/packages/plugins/inngest/package.json
+++ b/packages/plugins/inngest/package.json
@@ -47,26 +47,26 @@
     "definition": "dist/typings/index.d.ts"
   },
   "devDependencies": {
-    "@envelop/testing": "^5.0.6",
-    "@graphql-tools/utils": "^8.8.0",
-    "@types/fast-redact": "^3.0.2",
-    "@types/humps": "^2.0.2",
+    "@envelop/testing": "5.0.6",
+    "@graphql-tools/utils": "8.8.0",
+    "@types/fast-redact": "3.0.2",
+    "@types/humps": "2.0.2",
     "graphql": "16.6.0",
     "typescript": "4.8.4"
   },
   "dependencies": {
-    "@envelop/core": "^3.0.6",
-    "@graphql-tools/utils": "^8.8.0",
-    "@whatwg-node/fetch": "^0.6.5",
-    "fast-json-stable-stringify": "^2.1.0",
-    "fast-redact": "^3.1.2",
-    "humps": "^2.0.1",
-    "inngest": "^1.1.0",
-    "tslib": "^2.4.0"
+    "@envelop/core": "3.0.6",
+    "@graphql-tools/utils": "8.8.0",
+    "@whatwg-node/fetch": "0.6.5",
+    "fast-json-stable-stringify": "2.1.0",
+    "fast-redact": "3.1.2",
+    "humps": "2.0.1",
+    "inngest": "1.3.5",
+    "tslib": "2.4.0"
   },
   "peerDependencies": {
-    "@envelop/core": "^3.0.4",
-    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+    "@envelop/core": "3.0.4",
+    "graphql": "14.0.0 || 15.0.0 || 16.0.0"
   },
   "buildOptions": {
     "input": "./src/index.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,7 +1330,7 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
-"@envelop/core@^3.0.6":
+"@envelop/core@3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@envelop/core/-/core-3.0.6.tgz#e55c3564d05d648b0356a1c465aa90b0c51f485d"
   integrity sha512-06t1xCPXq6QFN7W1JUEf68aCwYN0OUDNAIoJe7bAqhaoa2vn7NCcuX1VHkJ/OWpmElUgCsRO6RiBbIru1in0Ig==
@@ -1338,7 +1338,7 @@
     "@envelop/types" "3.0.2"
     tslib "^2.5.0"
 
-"@envelop/testing@^5.0.6":
+"@envelop/testing@5.0.6":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@envelop/testing/-/testing-5.0.6.tgz#01d1c0f8c8f4dd68f1e5e12c8c76c1d910025fa5"
   integrity sha512-HP+j+w+/L1C2taznPOFCWkGBdrIBbqRo5suPPRKdS8GKRxsd8tQPOZz851TA65WEpZdc+fmzZMxV87nBPiTrqw==
@@ -2059,7 +2059,7 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/fast-redact@^3.0.2":
+"@types/fast-redact@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/fast-redact/-/fast-redact-3.0.2.tgz#ba2e62c56100283ee2030949119e985b0bb58104"
   integrity sha512-VQ8OBFBFnGT9hGbeBOzKrtHQYev7HN72tsD/7kxQ+/2tQ5PS9cifUOxT8Z42O6iNJK5QPN6IsFm7DNMw6Uq2SQ==
@@ -2071,7 +2071,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/humps@^2.0.2":
+"@types/humps@2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/humps/-/humps-2.0.2.tgz#6643e2beb13e0e7a22c65b2128b4315a727ecbe0"
   integrity sha512-FuyQoVNSW6mjSLxLVRq8YK1pi8P5zyL2pahEuCtMqlbmV4jyWYITz4eE2fZIErNovIfKU32tPbCl44VbOUaEiw==
@@ -2308,29 +2308,29 @@
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.34.0.tgz#d0139528320e46670d949c82967044a8f66db054"
   integrity sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==
 
-"@whatwg-node/events@^0.0.2":
+"@whatwg-node/events@0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@whatwg-node/events/-/events-0.0.2.tgz#7b7107268d2982fc7b7aff5ee6803c64018f84dd"
   integrity sha512-WKj/lI4QjnLuPrim0cfO7i+HsDSXHxNv1y0CrJhdntuO3hxWZmnXCwNDnwOvry11OjRin6cgWNF+j/9Pn8TN4w==
 
-"@whatwg-node/fetch@^0.6.5":
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.6.9.tgz#6cc694cc0378e27b8dfed427c5bf633eda6972b9"
-  integrity sha512-JfrBCJdMu9n9OARc0e/hPHcD98/8Nz1CKSdGYDg6VbObDkV/Ys30xe5i/wPOatYbxuvatj1kfWeHf7iNX3i17w==
+"@whatwg-node/fetch@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.6.5.tgz#ff96288e9a6295faafac79f13e3b3fd831cad11f"
+  integrity sha512-3XQ78RAMX8Az0LlUqMoGM3jbT+FE0S+IKr4yiTiqzQ5S/pNxD52K/kFLcLQiEbL+3rkk/glCHqjxF1QI5155Ig==
   dependencies:
     "@peculiar/webcrypto" "^1.4.0"
-    "@whatwg-node/node-fetch" "^0.0.5"
+    "@whatwg-node/node-fetch" "0.0.1"
     busboy "^1.6.0"
     urlpattern-polyfill "^6.0.2"
     web-streams-polyfill "^3.2.1"
 
-"@whatwg-node/node-fetch@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/node-fetch/-/node-fetch-0.0.5.tgz#bebf18891088e5e2fc449dea8d1bc94af5ec38df"
-  integrity sha512-hbccmaSZaItdsRuBKBEEhLoO+5oXJPxiyd0kG2xXd0Dh3Rt+vZn4pADHxuSiSHLd9CM+S2z4+IxlEGbWUgiz9g==
+"@whatwg-node/node-fetch@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@whatwg-node/node-fetch/-/node-fetch-0.0.1.tgz#ffad65f3f8b73d6d2c2e8b179d557a5863b0db13"
+  integrity sha512-dMbh604yf2jl37IzvYGA6z3heQg3dMzlqoNsiNToe46SVmKusfJXGf4KYIuiJTzh9mEEu/uVF//QakUfsLJpwA==
   dependencies:
-    "@whatwg-node/events" "^0.0.2"
-    busboy "^1.6.0"
+    "@whatwg-node/events" "0.0.2"
+    busboy "1.6.0"
     tslib "^2.3.1"
 
 "@yarnpkg/lockfile@^1.1.0":
@@ -2937,7 +2937,7 @@ bundle-require@^3.0.2:
   dependencies:
     load-tsconfig "^0.2.0"
 
-busboy@^1.6.0:
+busboy@1.6.0, busboy@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
   integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
@@ -2990,6 +2990,11 @@ caniuse-lite@^1.0.30001449:
   version "1.0.30001457"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz#6af34bb5d720074e2099432aa522c21555a18301"
   integrity sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==
+
+canonicalize@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.8.tgz#24d1f1a00ed202faafd9bf8e63352cd4450c6df1"
+  integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
 
 chalk@5.0.1:
   version "5.0.1"
@@ -4182,7 +4187,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.1.0, fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -4192,7 +4197,7 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-redact@^3.1.2:
+fast-redact@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.1.2.tgz#d58e69e9084ce9fa4c1a6fa98a3e1ecf5d7839aa"
   integrity sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==
@@ -4668,7 +4673,7 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-humps@^2.0.1:
+humps@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
   integrity sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==
@@ -4734,16 +4739,16 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inngest@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/inngest/-/inngest-1.2.0.tgz#28d49b22ecd5eb1b79ec2f9cfe2edbf01c1b5897"
-  integrity sha512-IBagpcMl9f/KWdhkHgK6zLYp9G0KZ+SNvN5OTAXsYNmNgJyb3NQihhZy4os7YLAta7psIIue7IRb6TNDdY89Hg==
+inngest@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/inngest/-/inngest-1.3.5.tgz#8fef0a1ed2ccc95c93d52ce39c6e4cf586a0e380"
+  integrity sha512-uYoBmFt4K7Z7m9dDQ3q2SGThToQMY2GrLAScitD2Jc9j7PTu/afuXSYGJHMTUJ8QhSMiY9u0gNRzhHs2sGFmYg==
   dependencies:
     buffer "^6.0.3"
+    canonicalize "^1.0.8"
     cross-fetch "^3.1.5"
     h3 "^1.0.2"
     hash.js "^1.1.7"
-    json-stringify-deterministic "^1.0.8"
     ms "^2.1.3"
     serialize-error-cjs "^0.1.3"
     type-fest "^3.5.1"
@@ -5529,11 +5534,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
-
-json-stringify-deterministic@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/json-stringify-deterministic/-/json-stringify-deterministic-1.0.8.tgz#675eaf26f18ebac0197c5e4d2d4dcc2ab3750948"
-  integrity sha512-rkJID3qeigo3VCrEcxX1333fTBBxW89YrdYcZexMnL/WdB8u0zctyG63e/DpahRJyrWCDhh7IQhiR7u2XEDQ4Q==
 
 json5@2.x, json5@^2.1.2, json5@^2.2.2:
   version "2.2.3"
@@ -7385,6 +7385,11 @@ tsconfig-paths@^3.14.1:
     json5 "^1.0.1"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
+
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
This PR updates to use the latest Inngest client.

It also removes pinning dependencies in anticipation of configuring renovate.