### PR TITLE
fix: Event names for capitalized operation names are built incorrectly

### DIFF
--- a/.changeset/hungry-ants-film.md
+++ b/.changeset/hungry-ants-film.md
@@ -1,0 +1,6 @@
+---
+'envelop-plugin-inngest': minor
+---
+
+Fixed https://github.com/inngest/envelop-plugin-inngest/issues/66 where event names for capitalized
+operation names are built incorrectly

--- a/packages/plugins/inngest/package.json
+++ b/packages/plugins/inngest/package.json
@@ -53,7 +53,6 @@
     "@whatwg-node/fetch": "0.8.8",
     "fast-json-stable-stringify": "2.1.0",
     "fast-redact": "3.1.2",
-    "humps": "2.0.1",
     "inngest": "1.8.0",
     "tslib": "2.5.0"
   },
@@ -61,7 +60,6 @@
     "@envelop/testing": "5.0.6",
     "@graphql-tools/utils": "9.2.1",
     "@types/fast-redact": "3.0.2",
-    "@types/humps": "2.0.2",
     "graphql": "16.6.0",
     "typescript": "5.0.4"
   },

--- a/packages/plugins/inngest/src/event-helpers.ts
+++ b/packages/plugins/inngest/src/event-helpers.ts
@@ -1,21 +1,32 @@
 import jsonStableStringify from 'fast-json-stable-stringify';
 import fastRedact from 'fast-redact';
-import pkg from 'humps';
 import { hashSHA256 } from './hash-sha256.js';
-import { USE_INNGEST_DEFAULT_EVENT_PREFIX, USE_INNGEST_ANONYMOUS_EVENT_PREFIX } from './plugin.js';
-import { getOperationInfo, buildTypeIdentifiers } from './schema-helpers.js';
+import { USE_INNGEST_ANONYMOUS_EVENT_PREFIX, USE_INNGEST_DEFAULT_EVENT_PREFIX } from './plugin.js';
+import { buildTypeIdentifiers, getOperationInfo } from './schema-helpers.js';
 import type {
-  UseInngestDataOptions,
-  UseInngestEventOptions,
-  UseInngestUserContextOptions,
   BuildEventNameFunction,
-  UseInngestEventNameFunctionOptions,
   BuildEventNamePrefixFunction,
   BuildUserContextFunction,
+  UseInngestDataOptions,
+  UseInngestEventNameFunctionOptions,
   UseInngestEventNamePrefixFunctionOptions,
+  UseInngestEventOptions,
+  UseInngestUserContextOptions,
 } from './types.js';
 
-const { decamelize } = pkg;
+/**
+ * Decamelize and convert to lowercase with dashes
+ *
+ * @param string
+ * @returns string
+ */
+const eventify = (text: string): string => {
+  return text
+    .replace(/^_+/, '')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[_\s]+/g, '-')
+    .toLowerCase();
+};
 
 /**
  * buildOperationId
@@ -61,9 +72,7 @@ export const buildOperationNameForEventName = async (options: UseInngestEventOpt
     operationName = `${USE_INNGEST_ANONYMOUS_EVENT_PREFIX}-${operationId}`;
   }
 
-  return decamelize(operationName, {
-    separator: '-',
-  });
+  return eventify(operationName);
 };
 
 /**
@@ -117,7 +126,7 @@ export const buildEventPayload = async (options: UseInngestDataOptions) => {
  * @returns string Prefix for event name
  */
 export const buildEventNamePrefix: BuildEventNamePrefixFunction = async (
-  options: UseInngestEventNamePrefixFunctionOptions
+  options: UseInngestEventNamePrefixFunctionOptions,
 ) => {
   return USE_INNGEST_DEFAULT_EVENT_PREFIX;
 };
@@ -130,7 +139,9 @@ export const buildEventNamePrefix: BuildEventNamePrefixFunction = async (
  * @param options UseInngestEventNameFunctionOptions
  * @returns string Event name
  */
-export const buildEventName: BuildEventNameFunction = async (options: UseInngestEventNameFunctionOptions) => {
+export const buildEventName: BuildEventNameFunction = async (
+  options: UseInngestEventNameFunctionOptions,
+) => {
   const operationName = await buildOperationNameForEventName(options);
   const { operationType } = getOperationInfo(options);
 
@@ -147,6 +158,8 @@ export const buildEventName: BuildEventNameFunction = async (options: UseInngest
  * @param options UseInngestUserContextOptions
  * @returns Object User info
  */
-export const buildUserContext: BuildUserContextFunction = (options: UseInngestUserContextOptions) => {
+export const buildUserContext: BuildUserContextFunction = (
+  options: UseInngestUserContextOptions,
+) => {
   return {};
 };

--- a/packages/setup/redwoodjs/README.md
+++ b/packages/setup/redwoodjs/README.md
@@ -84,9 +84,9 @@ side:
   +-- functions
       +- graphql.ts         // Modified GraphQLHandler to use Inngest plugin to instrument GraphQL api
       +- inngest.ts         // Inngest endpoint to serve functions
-  +-- jobs                   // Jobs
-    +-- inngest              // Directory where Inngest functions are stored
-        +- helloWorld.ts     // Example background function
+  +-- jobs                  // Jobs
+    +-- inngest             // Directory where Inngest functions are stored
+        +- helloWorld.ts    // Example background function
   +-- lib
       +- inngest.ts         // Inngest client. Use this if you need to send custom events in services or functions.
   +-- plugins
@@ -152,7 +152,7 @@ Options:
 
 ```
 
-The function command will create a new ready tom implement function file for the provided function
+The function command will create a new ready to implement function file for the provided function
 type.
 
 Supported types are:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,11 +2412,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/humps@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@types/humps/-/humps-2.0.2.tgz#6643e2beb13e0e7a22c65b2128b4315a727ecbe0"
-  integrity sha512-FuyQoVNSW6mjSLxLVRq8YK1pi8P5zyL2pahEuCtMqlbmV4jyWYITz4eE2fZIErNovIfKU32tPbCl44VbOUaEiw==
-
 "@types/is-ci@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/is-ci/-/is-ci-3.0.0.tgz#7e8910af6857601315592436f030aaa3ed9783c3"
@@ -4989,11 +4984,6 @@ humanize-string@2.1.0:
   integrity sha512-sQ+hqmxyXW8Cj7iqxcQxD7oSy3+AXnIZXdUF9lQMkzaG8dtbKAB8U7lCtViMnwQ+MpdCKsO2Kiij3G6UUXq/Xg==
   dependencies:
     decamelize "^2.0.0"
-
-humps@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
-  integrity sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==
 
 husky@8.0.3:
   version "8.0.3"


### PR DESCRIPTION
Fixes https://github.com/inngest/envelop-plugin-inngest/issues/66

Replaces humps "decamelize" with a custom "eventify" regex that just works better.