### PR TITLE
Fixed spacing to correctly render the "What if I don't want to auto-instrument my GraphQL API" header

### DIFF
--- a/packages/setup/redwoodjs/README.md
+++ b/packages/setup/redwoodjs/README.md
@@ -127,7 +127,7 @@ For more information, see
 [Creating an event key](https://www.inngest.com/docs/events/creating-an-event-key) in the Inngest
 documentation.
 
-###What if I don't want to auto-instrument my GraphQL API
+### What if I don't want to auto-instrument my GraphQL API
 
 While we highly agree with the philosophy to "instrument everything" by sending events for each
 GraphQL execution result to Inngest (aka auto-instrument) to effortlessly build event-driven


### PR DESCRIPTION
Fixed spacing to correctly render the "What if I don't want to auto-instrument my GraphQL API" header in the readme.