### PR TITLE
chore: Improves support for RedwoodJS experiment cli

### DIFF
--- a/.changeset/silly-taxis-obey.md
+++ b/.changeset/silly-taxis-obey.md
@@ -1,0 +1,5 @@
+---
+'inngest-setup-redwoodjs': patch
+---
+
+Improves the way RedwoodJS integrates its experimental setup cli command.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # envelop-plugin-inngest
 
-An envelop plugin that sends GraphQL response data to Inngest to help build event-driven applications.
+An envelop plugin that sends GraphQL response data to Inngest to help build event-driven
+applications.
 
-`useInngest` is an [Envelop](https://envelop.dev/) plugin for [GraphQL Yoga](https://envelop.dev/) and servers or frameworks powered by Yoga, such as [RedwoodJS](https://www.redwoodjs.com).
+`useInngest` is an [Envelop](https://envelop.dev/) plugin for [GraphQL Yoga](https://envelop.dev/)
+and servers or frameworks powered by Yoga, such as [RedwoodJS](https://www.redwoodjs.com).
 
 It's philosophy is to:
 
-- "instrument everything" by sending events for each GraphQL execution result to [Inngest](https://www.inngest.com) to effortlessly build event-driven applications.
-- provide fine-grained control over what events are sent such as operations (queries, mutations, or subscriptions), introspection events, when GraphQL errors occur, if result data should be included, type and schema coordinate denylists ... and more.
+- "instrument everything" by sending events for each GraphQL execution result to
+  [Inngest](https://www.inngest.com) to effortlessly build event-driven applications.
+- provide fine-grained control over what events are sent such as operations (queries, mutations, or
+  subscriptions), introspection events, when GraphQL errors occur, if result data should be
+  included, type and schema coordinate denylists ... and more.
 - be customized with event prefix, name and user context functions
 
 ## Packages
@@ -19,49 +24,71 @@ This monorepo contains several packages:
 
 ### envelop-plugin-inngest
 
-An envelop plugin that sends GraphQL response data to Inngest to help build event-driven applications.
+An envelop plugin that sends GraphQL response data to Inngest to help build event-driven
+applications.
 
 Please see the [plugin README](packages/plugins/inngest/README.md) to learn about the plugin.
 
-Or, if using [RedwoodJS](https://www.redwoodjs.com), see the [setup command README](packages/setup/redwoodjs/README.md) for instructions to configure and to create functions via command line.
+Or, if using [RedwoodJS](https://www.redwoodjs.com), see the
+[setup command README](packages/setup/redwoodjs/README.md) for instructions to configure and to
+create functions via command line.
 
 ### inngest-setup-redwoodjs
 
 Setup up Inngest in a RedwoodJS project and to create new functions via command line.
 
-The `plugin` command configures Inngest and auto-instruments the RedwoodJS GraphQL api using the envelop-plugin-inngest plugin.
+The `plugin` command configures Inngest and auto-instruments the RedwoodJS GraphQL api using the
+envelop-plugin-inngest plugin.
 
-The `function` command creates stubbed out background, delayed, scheduled and step functions ready for you to implement.
+The `function` command creates stubbed out background, delayed, scheduled and step functions ready
+for you to implement.
 
-Please see the [setup README](https://github.com/inngest/envelop-plugin-inngest/tree/main/packages/setup/redwoodjs) to learn about the setup command for RedwoodJS.
+Please see the
+[setup README](https://github.com/inngest/envelop-plugin-inngest/tree/main/packages/setup/redwoodjs)
+to learn about the setup command for RedwoodJS.
+
+> **Note:** If you use RedwoodJS v5.0.6-canary or later, you can setup Inngest via
+> `yarn rw experimental setup inngest`.
 
 ## About Inngest
 
-Inngest makes it simple for you to write delayed or background jobs by triggering functions from events — decoupling your code from your application.
+Inngest makes it simple for you to write delayed or background jobs by triggering functions from
+events — decoupling your code from your application.
 
 - You send events from your application via HTTP (or via third party webhooks, e.g. Stripe)
-- Inngest runs your serverless functions that are configured to be triggered by those events, either immediately, or delayed.
+- Inngest runs your serverless functions that are configured to be triggered by those events, either
+  immediately, or delayed.
 
-Inngest brings the benefits of event-driven systems to all developers, without having to write any code themselves.
+Inngest brings the benefits of event-driven systems to all developers, without having to write any
+code themselves.
 
 Inngest believes that:
 
 - Event-driven systems should be easy to build and adopt
 - Event-driven systems are better than regular, procedural systems and queues
 - Developer experience matters
-- Serverless scheduling enables scalable, reliable systems that are both cheaper and better for compliance
+- Serverless scheduling enables scalable, reliable systems that are both cheaper and better for
+  compliance
 
 ## About Yoga and Envelop
 
-[GraphQL Yoga](https://the-guild.dev/graphql/yoga-server) is a batteries-included cross-platform GraphQL over HTTP spec-compliant GraphQL server powered by[Envelop](https://envelop.dev/) and [GraphQL Tools](https://graphql-tools.com/).
+[GraphQL Yoga](https://the-guild.dev/graphql/yoga-server) is a batteries-included cross-platform
+GraphQL over HTTP spec-compliant GraphQL server powered by[Envelop](https://envelop.dev/) and
+[GraphQL Tools](https://graphql-tools.com/).
 
-Yoga uses Envelop under the hood so you can easily extend your server's capabilities with the plugins from Envelop Ecosystem.
+Yoga uses Envelop under the hood so you can easily extend your server's capabilities with the
+plugins from Envelop Ecosystem.
 
-[`Envelop`](https://envelop.dev/) is a lightweight JavaScript (/TypeScript) library for wrapping GraphQL execution layer and flow, allowing developers to develop, share and collaborate on GraphQL-related plugins while filling the missing pieces in GraphQL implementations.
+[`Envelop`](https://envelop.dev/) is a lightweight JavaScript (/TypeScript) library for wrapping
+GraphQL execution layer and flow, allowing developers to develop, share and collaborate on
+GraphQL-related plugins while filling the missing pieces in GraphQL implementations.
 
-Envelop aims to extend the GraphQL execution flow by adding plugins that enriches the feature set of your application.
+Envelop aims to extend the GraphQL execution flow by adding plugins that enriches the feature set of
+your application.
 
-Envelop provides a low-level hook-based plugin API for developers. By combining plugins, you can compose your own GraphQL "framework", and get a modified version of GraphQL with the capabilities you need.
+Envelop provides a low-level hook-based plugin API for developers. By combining plugins, you can
+compose your own GraphQL "framework", and get a modified version of GraphQL with the capabilities
+you need.
 
 Envelop is created and maintained by [The Guild](https://the-guild.dev/).
 

--- a/packages/plugins/inngest/README.md
+++ b/packages/plugins/inngest/README.md
@@ -1,13 +1,18 @@
 # envelop-plugin-inngest
 
-An envelop plugin that sends GraphQL response data to Inngest to help build event-driven applications.
+An envelop plugin that sends GraphQL response data to Inngest to help build event-driven
+applications.
 
-`useInngest` is an [Envelop](https://envelop.dev/) plugin for [GraphQL Yoga](https://envelop.dev/) and servers or frameworks powered by Yoga, such as [RedwoodJS](https://www.redwoodjs.com).
+`useInngest` is an [Envelop](https://envelop.dev/) plugin for [GraphQL Yoga](https://envelop.dev/)
+and servers or frameworks powered by Yoga, such as [RedwoodJS](https://www.redwoodjs.com).
 
 It's philosophy is to:
 
-- "instrument everything" by sending events for each GraphQL execution result to [Inngest](https://www.inngest.com) to effortlessly build event-driven applications.
-- provide fine-grained control over what events are sent such as operations (queries, mutations, or subscriptions), introspection events, when GraphQL errors occur, if result data should be included, type and schema coordinate denylists ... and more.
+- "instrument everything" by sending events for each GraphQL execution result to
+  [Inngest](https://www.inngest.com) to effortlessly build event-driven applications.
+- provide fine-grained control over what events are sent such as operations (queries, mutations, or
+  subscriptions), introspection events, when GraphQL errors occur, if result data should be
+  included, type and schema coordinate denylists ... and more.
 - be customized with event prefix, name and user context functions
 
 # Getting Started
@@ -16,15 +21,19 @@ It's philosophy is to:
 yarn add envelop-plugin-inngest
 ```
 
+> **Note:** If you use RedwoodJS v5.0.6-canary or later, you can setup Inngest via
+> `yarn rw experimental setup inngest`.
+
 ## Usage Example
 
-When configuring `useInngest`, you will need to setup and setup an [Inngest client](https://www.inngest.com/docs/quick-start) with the necessary [event keys](https://www.inngest.com/docs/events/creating-an-event-key).
+When configuring `useInngest`, you will need to setup and setup an
+[Inngest client](https://www.inngest.com/docs/quick-start) with the necessary
+[event keys](https://www.inngest.com/docs/events/creating-an-event-key).
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -54,13 +63,13 @@ server.listen(4000, () => {
 
 ### Logging
 
-You may set any [Yoga-compatible logger](https://the-guild.dev/graphql/yoga-server/docs/features/logging-and-debugging)
+You may set any
+[Yoga-compatible logger](https://the-guild.dev/graphql/yoga-server/docs/features/logging-and-debugging)
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema, createLogger } from 'graphql-yoga'
+import { createLogger, createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 const logger = createLogger()
@@ -86,10 +95,9 @@ const yoga = createYoga({
 #### Disable Logging
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema, createLogger } from 'graphql-yoga'
+import { createLogger, createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 const logger = createLogger()
@@ -115,10 +123,9 @@ const yoga = createYoga({
 #### Set Log Level
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema, createLogger } from 'graphql-yoga'
+import { createLogger, createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 const logger = createLogger()
@@ -145,7 +152,8 @@ const yoga = createYoga({
 
 You may need to customize the event name prefix or event name from its defaults.
 
-The event name prefix is `graphql` and the event name is constructed based on the operation name (aka the `noun` and type (aka the `verb`).
+The event name prefix is `graphql` and the event name is constructed based on the operation name
+(aka the `noun` and type (aka the `verb`).
 
 For example, the event name for a query of:
 
@@ -157,13 +165,13 @@ will be `graphql/test-query.query`
 
 #### Build Custom Event Name
 
-In the case where you want to completely override the function to construct the entire event name, you can define a `buildEventNameFunction`:
+In the case where you want to completely override the function to construct the entire event name,
+you can define a `buildEventNameFunction`:
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -192,13 +200,13 @@ const yoga = createYoga({
 
 #### Build Custom Event Name Prefix
 
-The `buildEventNamePrefixFunction` option lets you pass a function to customize the prefix for the event name
+The `buildEventNamePrefixFunction` option lets you pass a function to customize the prefix for the
+event name
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -227,17 +235,18 @@ const yoga = createYoga({
 
 ### User Context
 
-Inngest can also send user context information with the event to contain the user that perform the action.
+Inngest can also send user context information with the event to contain the user that perform the
+action.
 
-The `buildUserContextFunction` option let's you define the user context info sent with teh event, such as the authenticated user.
+The `buildUserContextFunction` option let's you define the user context info sent with teh event,
+such as the authenticated user.
 
 #### Build Custom User Context Info
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -272,7 +281,9 @@ const yoga = createYoga({
 
 You may not want to send every GraphQL result to Inngest.
 
-For example, you may want choose whether or not to send Subscriptions; or, you may want to send errors; or, you may want to block and events when the result data includes particular types or schema coordinates.
+For example, you may want choose whether or not to send Subscriptions; or, you may want to send
+errors; or, you may want to block and events when the result data includes particular types or
+schema coordinates.
 
 There are options that give you control over the defaults that:
 
@@ -286,10 +297,9 @@ There are options that give you control over the defaults that:
 To send only queries, configure the `sendOperations` option:
 
 ```ts
+import { createSchema, createYoga } from 'graphql-yoga'
 import { Inngest } from 'inngest'
-
-import { useInngest, SendableOperation } from '@envelop/inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { SendableOperation, useInngest } from '@envelop/inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -315,13 +325,13 @@ const yoga = createYoga({
 
 If you want to send the event even when an GraphQL Error occurs, you can set `sendErrors` to true.
 
-Note: that in order for you to include the error information, you will also need to set `includeRawResult` to `true` as well.
+Note: that in order for you to include the error information, you will also need to set
+`includeRawResult` to `true` as well.
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -345,13 +355,13 @@ const yoga = createYoga({
 
 #### Send Introspection Queries
 
-If you want to send an event when an introspection query occurs, you can set `sendIntrospection` to `true`:
+If you want to send an event when an introspection query occurs, you can set `sendIntrospection` to
+`true`:
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -375,15 +385,17 @@ const yoga = createYoga({
 
 #### Send Anonymous Queries
 
-If you want to send an event when an anonymous query occurs, you can set `sendAnonymousOperations` to `true`.
+If you want to send an event when an anonymous query occurs, you can set `sendAnonymousOperations`
+to `true`.
 
-Note: Anonymous query events will be send with an event name like `graphql/anonymous-d32327f2ad0fef67462baf2b8410a2b4b2cc8db57e67bb5b3c95efa595b39f30.query` where an operation id is generated based on the operation, document and variables in the request.
+Note: Anonymous query events will be send with an event name like
+`graphql/anonymous-d32327f2ad0fef67462baf2b8410a2b4b2cc8db57e67bb5b3c95efa595b39f30.query` where an
+operation id is generated based on the operation, document and variables in the request.
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -407,15 +419,15 @@ const yoga = createYoga({
 
 #### Do Not Send Events where Types or Schema Coordinates are in a Denylist
 
-There may a reason to block sending the event if the result data contains information for a certain type (like a `User`) or a particular schema coordinate (`Query.user`)
+There may a reason to block sending the event if the result data contains information for a certain
+type (like a `User`) or a particular schema coordinate (`Query.user`)
 
 ##### Deny list of Types
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -440,10 +452,9 @@ const yoga = createYoga({
 ##### Deny list of Schema Coordinates
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -472,10 +483,12 @@ const yoga = createYoga({
 
 ### Result Payload
 
-By default, `useInngest` does not send the entire raw result `{data: {}, errors: []}` in the payload because:
+By default, `useInngest` does not send the entire raw result `{data: {}, errors: []}` in the payload
+because:
 
 - Inngest has a max event payload of 512K and the information could be too large
-- The information needed to process the event in the Inngest handler is sent instead as `types` and `identifiers`.
+- The information needed to process the event in the Inngest handler is sent instead as `types` and
+  `identifiers`.
 
 For example, if the query
 
@@ -483,7 +496,8 @@ For example, if the query
 query FindPost { post { id title } }
 ```
 
-returns a single `Post`, the event payload will include the types in the result and the identifiers (ie, Post with id of 1) such that you can fetch the current data for the posts and handle as needed:
+returns a single `Post`, the event payload will include the types in the result and the identifiers
+(ie, Post with id of 1) such that you can fetch the current data for the posts and handle as needed:
 
 ```ts
 {
@@ -507,10 +521,9 @@ returns a single `Post`, the event payload will include the types in the result 
 You may send the complete raw result by setting `includeRawResult` to `true`:
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -535,10 +548,9 @@ const yoga = createYoga({
 ### Redact Sensitive Information from Result Data
 
 ```ts
-import { Inngest } from 'inngest'
-
 import { useInngest } from 'envelop-plugin-inngest'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { Inngest } from 'inngest'
 
 const inngestClient = new Inngest({ name: 'My App' })
 
@@ -574,11 +586,13 @@ const yoga = createYoga({
 
 Then the `body` will not show `Hello World!` but rather `[REDACTED]`.
 
-For a complete set of `RedactOptions`, please see [fast-redact](https://github.com/davidmarkclements/fast-redact).
+For a complete set of `RedactOptions`, please see
+[fast-redact](https://github.com/davidmarkclements/fast-redact).
 
 ### Redact Sensitive Information from Variables
 
-You may also want to prevent certain mutation variables to be sent as part of the event payload to redact sensitive info.
+You may also want to prevent certain mutation variables to be sent as part of the event payload to
+redact sensitive info.
 
 If your mutation updates a `User` email by id, you likely won't want to send their email.
 

--- a/packages/setup/redwoodjs/README.md
+++ b/packages/setup/redwoodjs/README.md
@@ -27,6 +27,9 @@ For example:
   },
 ```
 
+> **Note:** If you use RedwoodJS v5.0.6-canary or later, you can setup Inngest via
+> `yarn rw experimental setup inngest`.
+
 ## Usage
 
 ```

--- a/packages/setup/redwoodjs/src/function/tasks.ts
+++ b/packages/setup/redwoodjs/src/function/tasks.ts
@@ -18,7 +18,7 @@ export const tasks = (options: SetupFunctionTasksOptions) => {
         task: () => {
           const redwoodTomlPath = getConfigPath();
           const configContent = fs.readFileSync(redwoodTomlPath, 'utf-8');
-          const tomlKey = `[experimental.jobs.inngest.function.${options.type}]`;
+          const tomlKey = `[experimental.inngest]`;
           if (!configContent.includes(tomlKey)) {
             // Use string replace to preserve comments and formatting
             writeFile(redwoodTomlPath, configContent.concat(`\n${tomlKey}`), {

--- a/packages/setup/redwoodjs/src/plugin/tasks.ts
+++ b/packages/setup/redwoodjs/src/plugin/tasks.ts
@@ -51,7 +51,7 @@ export const tasks = (options: SetupPluginTasksOptions) => {
       },
 
       {
-        title: 'Configure inngest ...',
+        title: 'Configure Inngest ...',
         task: () => {
           configureInngestTask({ commandPaths, existingFiles });
         },
@@ -63,7 +63,7 @@ export const tasks = (options: SetupPluginTasksOptions) => {
         },
       },
       {
-        title: 'Add inngest helloWorld example ...',
+        title: 'Add Inngest helloWorld example ...',
         task: () => {
           addInngestHelloWorldExampleTask({ commandPaths, existingFiles });
         },
@@ -243,7 +243,7 @@ export const modifyGraphQLHandlerTask = async ({
 export const updateTomlConfig = () => {
   const redwoodTomlPath = getConfigPath();
   const configContent = fs.readFileSync(redwoodTomlPath, 'utf-8');
-  const tomlKey = '[experimental.jobs.inngest.plugin]';
+  const tomlKey = '[experimental.inngest]';
 
   if (!configContent.includes(tomlKey)) {
     // Use string replace to preserve comments and formatting

--- a/packages/setup/redwoodjs/tests/__snapshots__/plugin-tasks.test.ts.snap
+++ b/packages/setup/redwoodjs/tests/__snapshots__/plugin-tasks.test.ts.snap
@@ -107,5 +107,5 @@ export const inngest = new Inngest({
 
 exports[`Plugin tasks has updateTomlConfig 1`] = `
 "
-[experimental.jobs.inngest.plugin]"
+[experimental.inngest]"
 `;


### PR DESCRIPTION
RedwoodJS has a cli command structure around preview features or "experiments".

See: https://community.redwoodjs.com/t/about-the-experimental-features-category/4752

```
Experimentation is the life blood of Redwood’s roadmap and velocity. These are most often created by Core Team members and published so the entire community can participate:

* is is something people are excited to try and use?
* how can it be better and more useful?
* what’s broken, missing, confusing?
* general feedback

And, most importantly, it’s a way to collaborate on initiatives that will determine the project roadmap.
```

This will help other RedwoodJS users discover Inngest because they can find it via

```terminal
yarn rw experimental

rw experimental <command>

Run or setup experimental features

Commands:
  rw experimental inngest          Setup Inngest for background, scheduled,
                                   delayed, multi-step, and fan-out jobs
  rw experimental setup <command>  Setup experimental features
  rw experimental studio           Run the Redwood development studio
```

Once Inngest is setup, then the regular setup function commands can be used to generate functions.