### PR TITLE
feature: Upgrade to support Inngest SDK v2.0.0 new features and usage

### DIFF
--- a/.changeset/slow-jokes-count.md
+++ b/.changeset/slow-jokes-count.md
@@ -3,4 +3,6 @@
 'inngest-setup-redwoodjs': minor
 ---
 
-Updates to Inngest SDV v2
+Updates to Inngest SDK v2
+
+## Breaking Changes

--- a/.changeset/slow-jokes-count.md
+++ b/.changeset/slow-jokes-count.md
@@ -1,0 +1,6 @@
+---
+'envelop-plugin-inngest': minor
+'inngest-setup-redwoodjs': minor
+---
+
+Updates to Inngest SDV v2

--- a/.changeset/slow-jokes-count.md
+++ b/.changeset/slow-jokes-count.md
@@ -1,8 +1,113 @@
 ---
-'envelop-plugin-inngest': minor
-'inngest-setup-redwoodjs': minor
+'envelop-plugin-inngest': major
+'inngest-setup-redwoodjs': major
 ---
 
 Updates to Inngest SDK v2
 
 ## Breaking Changes
+
+Inngest SDK v2 has some breaking changes that will require some manual code change to existing apps.
+
+### Logging
+
+Logging has changed in v2. See: https://www.inngest.com/docs/guides/logging.
+
+It is now set in the client and used as part of Inngest's middleware. The plugin will try to use the
+Inngest client's logger first and then this logger setting.
+
+```ts
+// api/src/lib/inngest.ts
+import { Inngest } from 'inngest'
+import { logger } from './logger'
+
+export const INNGEST_APP_NAME = 'Redwood_Inngest'
+
+export const inngest = new Inngest({
+  /**
+   * The name of this instance, most commonly the name of the application it
+   * resides in.
+   */
+  name: INNGEST_APP_NAME,
+  /**
+   * Inngest event key, used to send events to Inngest Cloud. If not provided,
+   * will search for the `INNGEST_EVENT_KEY` environment variable. If neither
+   * can be found, however, a warning will be shown and any attempts to send
+   * events will throw an error.
+   */
+  eventKey: 'YOUR_INNGEST_EVENT_KEY',
+  /**
+   * Use the api logger for Inngest function logging, useful in scheduled functions
+   */
+  logger: logger,
+  logLevel: 'info'
+})
+```
+
+### Delayed Functions
+
+In addition to delaying via a `sleep` duration, you can now `sleepUntil` a timestamp or a variable
+in event data:
+
+```ts
+  async ({ event, step }) => {
+     await step.sleep('5s')
+
+     // You can run jobs at a specific time using the step.sleepUntil() utility:
+     // await step.sleepUntil("2023-04-01T12:30:00");
+
+     // You can also sleep until a timestamp within the event data.  This lets you
+     // pass in a time for you to run the job:
+     // await step.sleepUntil(event.data.run_at) // Assuming event.data.run_at is a timestamp.
+```
+
+### Scheduled Functions
+
+A scheduled function now uses the logger to output success rather than a payload message.
+
+Note that one can access Inngest's `logger` set on the client from the `event`:
+
+```ts
+  async (event) => {
+     const payload = {
+       message: `Scheduled ${humanizedName} function ran.`,
+       runAt: Date.now().toString(),
+     }
+     event.logger.debug(payload, `${humanizedName} function ran.`)
+   }
+ )
+```
+
+### RedwoodJS
+
+1. The `api/src/functions/inngest.ts` function has several changes:
+
+- In the `serve` handler, instead of the `INNGEST_APP_NAME` now one passes the complete `inngest`
+  client.
+
+```ts
+// Serve your Inngest functions
+export const handler = serve(inngest, inngestFunctions,
+```
+
+This name is still defined in `api/src/lib/inngest.ts`:
+
+```ts
+export const INNGEST_APP_NAME = 'Redwood_Inngest'
+
+export const inngest = new Inngest({
+  /**
+   * The name of this instance, most commonly the name of the application it
+   * resides in.
+   */
+  name: INNGEST_APP_NAME,
+```
+
+2. RedwoodJS v6 canary builds may need the `serve` path to be
+   `servePath: '/.redwood/functions/inngest'` instead of simply `/inngest`.
+
+One you then start the Inngest dev server as:
+
+```bash
+npx inngest-cli@latest dev -u http://localhost:8910/.redwood/functions/inngest
+```

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@changesets/cli": "^2.26.1",
     "@graphql-tools/schema": "10.0.0",
     "@theguild/prettier-config": "1.2.0",
-    "@types/jest": "29.5.1",
+    "@types/jest": "29.5.2",
     "@types/node": "18.16.18",
     "@typescript-eslint/eslint-plugin": "5.59.11",
     "@typescript-eslint/parser": "5.59.11",

--- a/packages/plugins/inngest/CONTRIBUTING.md
+++ b/packages/plugins/inngest/CONTRIBUTING.md
@@ -35,7 +35,9 @@ and then `yarn` and then build, test, and run type check.
 
 Be sure to restore current packages for latest GraphQL dependency.
 
-5. Create a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) via `yarn changeset`
+5. Create a
+   [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) via
+   `yarn changeset`
 
 ## All
 

--- a/packages/plugins/inngest/README.md
+++ b/packages/plugins/inngest/README.md
@@ -67,8 +67,6 @@ Logging has changed in v2. See: https://www.inngest.com/docs/guides/logging. It 
 client and used as part of Inngest's middleware. The plugin will try to use the Inngest client's
 logger first and then this logger setting.
 
-TODO: Is logging doubled up?
-
 You may set any
 [Yoga-compatible logger](https://the-guild.dev/graphql/yoga-server/docs/features/logging-and-debugging)
 

--- a/packages/plugins/inngest/README.md
+++ b/packages/plugins/inngest/README.md
@@ -63,6 +63,12 @@ server.listen(4000, () => {
 
 ### Logging
 
+Logging has changed in v2. See: https://www.inngest.com/docs/guides/logging. It is now set in the
+client and used as part of Inngest's middleware. The plugin will try to use the Inngest client's
+logger first and then this logger setting.
+
+TODO: Is logging doubled up?
+
 You may set any
 [Yoga-compatible logger](https://the-guild.dev/graphql/yoga-server/docs/features/logging-and-debugging)
 

--- a/packages/plugins/inngest/package.json
+++ b/packages/plugins/inngest/package.json
@@ -44,7 +44,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "peerDependencies": {
-    "@envelop/core": "3.0.6",
+    "@envelop/core": "4.0.0",
     "graphql": "14.0.0 || 15.0.0 || 16.0.0 || 16.6.0"
   },
   "dependencies": {
@@ -53,7 +53,7 @@
     "@whatwg-node/fetch": "0.9.6",
     "fast-json-stable-stringify": "2.1.0",
     "fast-redact": "3.1.2",
-    "inngest": "1.9.7",
+    "inngest": "2.0.2",
     "tslib": "2.5.3"
   },
   "devDependencies": {

--- a/packages/plugins/inngest/src/plugin.ts
+++ b/packages/plugins/inngest/src/plugin.ts
@@ -1,6 +1,11 @@
 import { ExecutionResult, Plugin } from '@envelop/core';
 import { defaultGetDocumentString, useCacheDocumentString } from './cache-document-str.js';
-import { buildEventPayload, buildEventName, buildEventNamePrefix, buildUserContext } from './event-helpers.js';
+import {
+  buildEventName,
+  buildEventNamePrefix,
+  buildEventPayload,
+  buildUserContext,
+} from './event-helpers.js';
 import { buildLogger } from './logger.js';
 import { shouldSendEvent } from './should-send-event.js';
 import type { UseInngestPluginOptions } from './types.js';
@@ -29,7 +34,8 @@ export const useInngest = ({
   redactRawResultOptions = undefined,
   logging = false,
 }: UseInngestPluginOptions): Plugin => {
-  const logger = buildLogger({ logging });
+  // eslint-disable-next-line dot-notation
+  const logger = inngestClient['logger'] || buildLogger({ logging });
   const getDocumentString = defaultGetDocumentString;
 
   return {
@@ -40,7 +46,10 @@ export const useInngest = ({
       return {
         async onExecuteDone({ result }) {
           try {
-            const eventNamePrefix = await buildEventNamePrefixFunction({ params: onExecuteParams, logger });
+            const eventNamePrefix = await buildEventNamePrefixFunction({
+              params: onExecuteParams,
+              logger,
+            });
             const eventName = await buildEventNameFunction({
               params: onExecuteParams,
               documentString: getDocumentString(onExecuteParams.args),

--- a/packages/plugins/inngest/src/types.ts
+++ b/packages/plugins/inngest/src/types.ts
@@ -1,7 +1,7 @@
-import { OperationTypeNode } from 'graphql';
-import type { ExecutionResult, OnExecuteEventPayload } from '@envelop/core';
 import type { RedactOptions } from 'fast-redact';
-import type { Inngest, EventPayload } from 'inngest';
+import { OperationTypeNode } from 'graphql';
+import type { Inngest } from 'inngest';
+import type { ExecutionResult, OnExecuteEventPayload } from '@envelop/core';
 
 /**
  * UseInngestPluginOptions
@@ -21,7 +21,7 @@ import type { Inngest, EventPayload } from 'inngest';
  * @param redactRawResultOptions Redaction
  */
 export interface UseInngestPluginOptions {
-  inngestClient: Inngest<Record<string, EventPayload>>;
+  inngestClient: Inngest;
   buildEventNameFunction?: BuildEventNameFunction;
   buildEventNamePrefixFunction?: BuildEventNamePrefixFunction;
   buildUserContextFunction?: BuildUserContextFunction;
@@ -91,7 +91,10 @@ export type UseInngestDataOptions = {
   UseInngestLoggerOptions &
   Omit<
     UseInngestPluginOptions,
-    'inngestClient' | 'buildEventNameFunction' | 'buildEventNamePrefixFunction' | 'buildUserContextFunction'
+    | 'inngestClient'
+    | 'buildEventNameFunction'
+    | 'buildEventNamePrefixFunction'
+    | 'buildUserContextFunction'
   >;
 
 /**
@@ -142,7 +145,7 @@ export type UseInngestUserContextOptions = UseInngestExecuteOptions & UseInngest
  * @param options UseInngestUserContextOptions
  */
 export type BuildUserContextFunction = (
-  options: UseInngestUserContextOptions
+  options: UseInngestUserContextOptions,
 ) => InngestUserContext | Promise<InngestUserContext>;
 
 /**
@@ -151,7 +154,9 @@ export type BuildUserContextFunction = (
  * @param options UseInngestEventNamePrefixFunctionOptions
  * @returns Event name prefix
  */
-export type BuildEventNamePrefixFunction = (options: UseInngestEventNamePrefixFunctionOptions) => Promise<string>;
+export type BuildEventNamePrefixFunction = (
+  options: UseInngestEventNamePrefixFunctionOptions,
+) => Promise<string>;
 
 /**
  * BuildEventNameFunction
@@ -160,7 +165,9 @@ export type BuildEventNamePrefixFunction = (options: UseInngestEventNamePrefixFu
  * @returns Event name
  */
 
-export type BuildEventNameFunction = (options: UseInngestEventNameFunctionOptions) => Promise<string>;
+export type BuildEventNameFunction = (
+  options: UseInngestEventNameFunctionOptions,
+) => Promise<string>;
 
 /**
  * UseInngestLoggerOptions
@@ -181,4 +188,7 @@ export type ContextType = Record<string, any>;
  *
  * @returns operationName and operationType
  */
-export type OperationInfo = { operationName: string | undefined; operationType: OperationTypeNode | 'unknown' };
+export type OperationInfo = {
+  operationName: string | undefined;
+  operationType: OperationTypeNode | 'unknown';
+};

--- a/packages/plugins/inngest/tests/plugin.spec.ts
+++ b/packages/plugins/inngest/tests/plugin.spec.ts
@@ -1,10 +1,9 @@
-import { assertSingleExecutionValue, createTestkit, createSpiedPlugin } from '@envelop/testing';
+import { parse } from 'graphql';
+import type { EventPayload, Inngest } from 'inngest';
+import { assertSingleExecutionValue, createSpiedPlugin, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { createGraphQLError } from '@graphql-tools/utils';
-import { parse } from 'graphql';
 import { useInngest } from '../src/plugin';
-
-import type { EventPayload, Inngest } from 'inngest';
 
 describe('useInngest', () => {
   const testEventKey = 'foo-bar-baz-test';
@@ -64,7 +63,7 @@ describe('useInngest', () => {
     eventKey: testEventKey,
     send: jest.fn(),
     setEventKey: jest.fn(),
-  } as unknown as Inngest<Record<string, EventPayload>>;
+  } as unknown as Inngest;
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -76,7 +75,7 @@ describe('useInngest', () => {
 
       const testInstance = createTestkit(
         [useInngest({ inngestClient: mockedInngestClient }), spiedPlugin.plugin],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query TestQuery2 { test }`);
@@ -105,7 +104,7 @@ describe('useInngest', () => {
 
       const testInstance = createTestkit(
         [useInngest({ inngestClient: mockedInngestClient }), spiedPlugin.plugin],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query FindPost { post { id title } }`);
@@ -139,13 +138,17 @@ describe('useInngest', () => {
 
       const testInstance = createTestkit(
         [useInngest({ inngestClient: mockedInngestClient }), spiedPlugin.plugin],
-        schema
+        schema,
       );
 
-      const result = await testInstance.execute(`query FindPost { post { id title comments { id body } } }`);
+      const result = await testInstance.execute(
+        `query FindPost { post { id title comments { id body } } }`,
+      );
       assertSingleExecutionValue(result);
 
-      expect(result.data).toEqual({ post: { id: '1', title: 'hello', comments: [{ id: '3', body: 'message' }] } });
+      expect(result.data).toEqual({
+        post: { id: '1', title: 'hello', comments: [{ id: '3', body: 'message' }] },
+      });
       expect(result.errors).toBeUndefined();
 
       expect(spiedPlugin.spies.afterExecute).toHaveBeenCalled();
@@ -179,12 +182,14 @@ describe('useInngest', () => {
 
       const testInstance = createTestkit(
         [useInngest({ inngestClient: mockedInngestClient, logging: true }), spiedPlugin.plugin],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(
-        parse(`mutation UpdateMyPost($id: ID!, $title: String!) { updatePost(id: $id, title: $title) { id title } }`),
-        { id: 99, title: 'Title TK' }
+        parse(
+          `mutation UpdateMyPost($id: ID!, $title: String!) { updatePost(id: $id, title: $title) { id title } }`,
+        ),
+        { id: 99, title: 'Title TK' },
       );
       assertSingleExecutionValue(result);
 
@@ -213,7 +218,7 @@ describe('useInngest', () => {
 
       const testInstance = createTestkit(
         [useInngest({ inngestClient: mockedInngestClient }), spiedPlugin.plugin],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query { test }`);
@@ -231,8 +236,11 @@ describe('useInngest', () => {
       const spiedPlugin = createSpiedPlugin();
 
       const testInstance = createTestkit(
-        [useInngest({ inngestClient: mockedInngestClient, sendAnonymousOperations: true }), spiedPlugin.plugin],
-        schema
+        [
+          useInngest({ inngestClient: mockedInngestClient, sendAnonymousOperations: true }),
+          spiedPlugin.plugin,
+        ],
+        schema,
       );
 
       const result = await testInstance.execute(`query { test }`);
@@ -266,8 +274,11 @@ describe('useInngest', () => {
       const spiedPlugin = createSpiedPlugin();
 
       const testInstance = createTestkit(
-        [useInngest({ inngestClient: mockedInngestClient, sendIntrospection: true }), spiedPlugin.plugin],
-        schema
+        [
+          useInngest({ inngestClient: mockedInngestClient, sendIntrospection: true }),
+          spiedPlugin.plugin,
+        ],
+        schema,
       );
 
       const result = await testInstance.execute(`{
@@ -358,8 +369,11 @@ describe('useInngest', () => {
       const spiedPlugin = createSpiedPlugin();
 
       const testInstance = createTestkit(
-        [useInngest({ inngestClient: mockedInngestClient, sendIntrospection: false }), spiedPlugin.plugin],
-        schema
+        [
+          useInngest({ inngestClient: mockedInngestClient, sendIntrospection: false }),
+          spiedPlugin.plugin,
+        ],
+        schema,
       );
 
       const result = await testInstance.execute(`{
@@ -439,7 +453,7 @@ describe('useInngest', () => {
 
       const testInstance = createTestkit(
         [useInngest({ inngestClient: mockedInngestClient, sendErrors: true }), spiedPlugin.plugin],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query FailQuery { fails }`);
@@ -458,7 +472,7 @@ describe('useInngest', () => {
 
       const testInstance = createTestkit(
         [useInngest({ inngestClient: mockedInngestClient }), spiedPlugin.plugin],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query FailQuery { fails }`);
@@ -478,8 +492,11 @@ describe('useInngest', () => {
       const spiedPlugin = createSpiedPlugin();
 
       const testInstance = createTestkit(
-        [useInngest({ inngestClient: mockedInngestClient, denylist: { types: ['Post'] } }), spiedPlugin.plugin],
-        schema
+        [
+          useInngest({ inngestClient: mockedInngestClient, denylist: { types: ['Post'] } }),
+          spiedPlugin.plugin,
+        ],
+        schema,
       );
 
       const result = await testInstance.execute(`query FindPost { post { id title } }`);
@@ -498,10 +515,13 @@ describe('useInngest', () => {
 
       const testInstance = createTestkit(
         [
-          useInngest({ inngestClient: mockedInngestClient, denylist: { schemaCoordinates: ['Query.post'] } }),
+          useInngest({
+            inngestClient: mockedInngestClient,
+            denylist: { schemaCoordinates: ['Query.post'] },
+          }),
           spiedPlugin.plugin,
         ],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query FindPost { post { id title } }`);
@@ -521,8 +541,11 @@ describe('useInngest', () => {
       const spiedPlugin = createSpiedPlugin();
 
       const testInstance = createTestkit(
-        [useInngest({ inngestClient: mockedInngestClient, includeRawResult: true }), spiedPlugin.plugin],
-        schema
+        [
+          useInngest({ inngestClient: mockedInngestClient, includeRawResult: true }),
+          spiedPlugin.plugin,
+        ],
+        schema,
       );
 
       const result = await testInstance.execute(`query TestQuery2 { test }`);
@@ -560,7 +583,7 @@ describe('useInngest', () => {
           }),
           spiedPlugin.plugin,
         ],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query TestQuery2 { test }`);
@@ -596,12 +619,14 @@ describe('useInngest', () => {
           }),
           spiedPlugin.plugin,
         ],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(
-        parse(`mutation UpdateMyPost($id: ID!, $title: String!) { updatePost(id: $id, title: $title) { id title } }`),
-        { id: 99, title: 'Title TK' }
+        parse(
+          `mutation UpdateMyPost($id: ID!, $title: String!) { updatePost(id: $id, title: $title) { id title } }`,
+        ),
+        { id: 99, title: 'Title TK' },
       );
       assertSingleExecutionValue(result);
 
@@ -636,7 +661,7 @@ describe('useInngest', () => {
           }),
           spiedPlugin.plugin,
         ],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query TestQuery5 { test }`);
@@ -673,7 +698,7 @@ describe('useInngest', () => {
           }),
           spiedPlugin.plugin,
         ],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query TestQuery6 { test }`);
@@ -712,7 +737,7 @@ describe('useInngest', () => {
           }),
           spiedPlugin.plugin,
         ],
-        schema
+        schema,
       );
 
       const result = await testInstance.execute(`query TestQuery6 { test }`);

--- a/packages/setup/redwoodjs/README.md
+++ b/packages/setup/redwoodjs/README.md
@@ -20,7 +20,7 @@ yarn add -D inngest-setup-redwoodjs
 For example:
 
 ```
-  // package.json]
+  // package.json
   "devDependencies": {
     ...
     "inngest-setup-redwoodjs": "latest"
@@ -207,7 +207,7 @@ and setup your RedwoodJS app to use Inngest.
 To launch the SDK Dashboard, visit:
 
 ```
-http://localhost:8911/inngest
+http://localhost:8910/.redwood/functions/inngest
 ```
 
 Here, you can see which functions have be been found and registered.
@@ -217,7 +217,7 @@ Here, you can see which functions have be been found and registered.
 To launch the Inngest dev server, from a new terminal run:
 
 ```
-npx inngest-cli@latest dev -u http://localhost:8911/inngest
+npx inngest-cli@latest dev -u http://localhost:8910/.redwood/functions/inngest
 ```
 
 There will be instructions for the url to visit to view the dev server UI.

--- a/packages/setup/redwoodjs/templates/function/delayed.ts.template
+++ b/packages/setup/redwoodjs/templates/function/delayed.ts.template
@@ -16,6 +16,13 @@ export const ${functionName} = inngest.createFunction(
   async ({ event, step }) => {
     await step.sleep('5s')
 
+    // You can run jobs at a specific time using the step.sleepUntil() utility:
+    // await step.sleepUntil("2023-04-01T12:30:00");
+
+    // You can also sleep until a timestamp within the event data.  This lets you
+    // pass in a time for you to run the job:
+    // await step.sleepUntil(event.data.run_at) // Assuming event.data.run_at is a timestamp.    
+
     return {
       event,
       body: 'Delayed function ${humanizedName} waited for 5 seconds',

--- a/packages/setup/redwoodjs/templates/function/scheduled.ts.template
+++ b/packages/setup/redwoodjs/templates/function/scheduled.ts.template
@@ -9,10 +9,13 @@ export const ${functionName} = inngest.createFunction(
 
   // This function will be called on the schedule defined in the cron property.
   // When implementing your function, you have access to the { event, step }.
-  async () => {
-    return {
+  async (event) => {
+    const payload = {
       message: `Scheduled ${humanizedName} function ran.`,
       runAt: Date.now().toString(),
     }
+    event.logger.debug(payload, `${humanizedName} function ran.`)
   }
 )
+
+

--- a/packages/setup/redwoodjs/templates/plugin/client.ts.template
+++ b/packages/setup/redwoodjs/templates/plugin/client.ts.template
@@ -1,5 +1,7 @@
 import { Inngest } from 'inngest'
 
+import { logger } from './logger'
+
 export const INNGEST_APP_NAME = 'Redwood_Inngest'
 
 export const inngest = new Inngest({
@@ -15,4 +17,9 @@ export const inngest = new Inngest({
    * events will throw an error.
    */
   eventKey: 'YOUR_INNGEST_EVENT_KEY',
+  /**
+   * Use the api logger for Inngest function logging, useful in scheduled functions
+   */
+  logger: logger,
+  logLevel: 'info',
 })

--- a/packages/setup/redwoodjs/templates/plugin/inngest.ts.template
+++ b/packages/setup/redwoodjs/templates/plugin/inngest.ts.template
@@ -1,20 +1,48 @@
 import { serve } from 'inngest/redwood'
 
 import helloWorld from 'src/jobs/inngest/helloWorld'
-import { INNGEST_APP_NAME } from 'src/lib/inngest'
+import { inngest } from 'src/lib/inngest'
+import { logger } from 'src/lib/logger'
 
 // Add your Inngest functions here
 const inngestFunctions = [helloWorld]
 
 // Serve your Inngest functions
-export const handler = serve(INNGEST_APP_NAME, inngestFunctions, {
-  servePath: '/inngest',
+export const handler = serve(inngest, inngestFunctions, {
+  servePath: '/.redwood/functions/inngest',
+  /**
+   * The Inngest environment to send events to. Defaults to whichever
+   * environment this client's event key is associated with.
+   *
+   * It's likely you never need to change this unless you're trying to sync
+   * multiple systems together using branch names.
+   *
+   * See: https://www.inngest.com/docs/platform/environments
+   */
+  // env: 'process.env.YOUR_ENVIRONMENT',
+
+  /**
+   * The logger provided by the user.
+   * The user can passed in their winston, pino, and other loggers for
+   * handling log delivery to external services.
+   *
+   * The provider logger is expected to implement the following API interfaces
+   * - .info()
+   * - .warn()
+   * - .debug()
+   * - .error()
+   * which most loggers already do.
+   *
+   */
+  logger: logger,
+
   /**
    * The minimum level to log from the Inngest serve endpoint.
    *
    * Default level: "info"
    */
   logLevel: 'info',
+  
   /**
    * A key used to sign requests to and from Inngest in order to prove that the
    * source is legitimate in Production.

--- a/packages/setup/redwoodjs/tests/__snapshots__/plugin-tasks.test.ts.snap
+++ b/packages/setup/redwoodjs/tests/__snapshots__/plugin-tasks.test.ts.snap
@@ -86,6 +86,8 @@ exports[`Plugin tasks has addScriptToPackageJsonTask 1`] = `
 exports[`Plugin tasks has configureInngestTask 1`] = `
 "import { Inngest } from 'inngest'
 
+import { logger } from './logger'
+
 export const INNGEST_APP_NAME = 'Redwood_Inngest'
 
 export const inngest = new Inngest({
@@ -101,6 +103,11 @@ export const inngest = new Inngest({
    * events will throw an error.
    */
   eventKey: 'YOUR_INNGEST_EVENT_KEY',
+  /**
+   * Use the api logger for Inngest function logging, useful in scheduled functions
+   */
+  logger: logger,
+  logLevel: 'info',
 })
 "
 `;

--- a/packages/setup/redwoodjs/tests/__snapshots__/render-function-template.test.ts.snap
+++ b/packages/setup/redwoodjs/tests/__snapshots__/render-function-template.test.ts.snap
@@ -49,6 +49,13 @@ export const onPostDelete = inngest.createFunction(
   async ({ event, step }) => {
     await step.sleep('5s')
 
+    // You can run jobs at a specific time using the step.sleepUntil() utility:
+    // await step.sleepUntil("2023-04-01T12:30:00");
+
+    // You can also sleep until a timestamp within the event data.  This lets you
+    // pass in a time for you to run the job:
+    // await step.sleepUntil(event.data.run_at) // Assuming event.data.run_at is a timestamp.    
+
     return {
       event,
       body: 'Delayed function On post delete waited for 5 seconds',
@@ -273,6 +280,13 @@ export const getPostBySlug = inngest.createFunction(
   async ({ event, step }) => {
     await step.sleep('5s')
 
+    // You can run jobs at a specific time using the step.sleepUntil() utility:
+    // await step.sleepUntil("2023-04-01T12:30:00");
+
+    // You can also sleep until a timestamp within the event data.  This lets you
+    // pass in a time for you to run the job:
+    // await step.sleepUntil(event.data.run_at) // Assuming event.data.run_at is a timestamp.    
+
     return {
       event,
       body: 'Delayed function Get post by slug waited for 5 seconds',
@@ -294,13 +308,16 @@ export const getAllPosts = inngest.createFunction(
 
   // This function will be called on the schedule defined in the cron property.
   // When implementing your function, you have access to the { event, step }.
-  async () => {
-    return {
+  async (event) => {
+    const payload = {
       message: \`Scheduled Get all posts function ran.\`,
       runAt: Date.now().toString(),
     }
+    event.logger.debug(payload, \`Get all posts function ran.\`)
   }
 )
+
+
 "
 `;
 
@@ -415,6 +432,13 @@ export const afterCheckout = inngest.createFunction(
   async ({ event, step }) => {
     await step.sleep('5s')
 
+    // You can run jobs at a specific time using the step.sleepUntil() utility:
+    // await step.sleepUntil("2023-04-01T12:30:00");
+
+    // You can also sleep until a timestamp within the event data.  This lets you
+    // pass in a time for you to run the job:
+    // await step.sleepUntil(event.data.run_at) // Assuming event.data.run_at is a timestamp.    
+
     return {
       event,
       body: 'Delayed function After checkout waited for 5 seconds',
@@ -510,13 +534,16 @@ export const test = inngest.createFunction(
 
   // This function will be called on the schedule defined in the cron property.
   // When implementing your function, you have access to the { event, step }.
-  async () => {
-    return {
+  async (event) => {
+    const payload = {
       message: \`Scheduled Test function ran.\`,
       runAt: Date.now().toString(),
     }
+    event.logger.debug(payload, \`Test function ran.\`)
   }
 )
+
+
 "
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,10 +2685,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@29.5.1":
-  version "29.5.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.1.tgz#83c818aa9a87da27d6da85d3378e5a34d2f31a47"
-  integrity sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==
+"@types/jest@29.5.2":
+  version "29.5.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.2.tgz#86b4afc86e3a8f3005b297ed8a72494f89e6395b"
+  integrity sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -5292,10 +5292,10 @@ ini@^1.3.4:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-inngest@1.9.7:
-  version "1.9.7"
-  resolved "https://registry.yarnpkg.com/inngest/-/inngest-1.9.7.tgz#39220effae7a2c8ea5deef4f78ef11a2f089f876"
-  integrity sha512-OxDfn2MAQgEW7jHElTD2LIvR+5BEBAFa6A4p4MAi+kc95qahkSIA7ZmeP9pQvVnGQu6ivFaIsFAbKorW0ZlYGw==
+inngest@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/inngest/-/inngest-2.0.2.tgz#f6caa5d14c288cfd5e131e33ddaa9f6a636102a6"
+  integrity sha512-VlqrpcgqztqHmkAcWG/PrfdhHSnwGUozpqBAgzRFT4Jnplgg6LBotIqdjMqgjvJXMTpPF481WvMiTYr+XMaOew==
   dependencies:
     buffer "^6.0.3"
     canonicalize "^1.0.8"


### PR DESCRIPTION

Updates to Inngest SDK v2

## Breaking Changes

Inngest SDK v2 has some breaking changes that will require some manual code change to existing apps.

### Logging

Logging has changed in v2. See: https://www.inngest.com/docs/guides/logging.

It is now set in the client and used as part of Inngest's middleware. The plugin will try to use the
Inngest client's logger first and then this logger setting.

```ts
// api/src/lib/inngest.ts
import { Inngest } from 'inngest'
import { logger } from './logger'

export const INNGEST_APP_NAME = 'Redwood_Inngest'

export const inngest = new Inngest({
  /**
   * The name of this instance, most commonly the name of the application it
   * resides in.
   */
  name: INNGEST_APP_NAME,
  /**
   * Inngest event key, used to send events to Inngest Cloud. If not provided,
   * will search for the `INNGEST_EVENT_KEY` environment variable. If neither
   * can be found, however, a warning will be shown and any attempts to send
   * events will throw an error.
   */
  eventKey: 'YOUR_INNGEST_EVENT_KEY',
  /**
   * Use the api logger for Inngest function logging, useful in scheduled functions
   */
  logger: logger,
  logLevel: 'info'
})
```

### Delayed Functions

In addition to delaying via a `sleep` duration, you can now `sleepUntil` a timestamp or a variable
in event data:

```ts
  async ({ event, step }) => {
     await step.sleep('5s')

     // You can run jobs at a specific time using the step.sleepUntil() utility:
     // await step.sleepUntil("2023-04-01T12:30:00");

     // You can also sleep until a timestamp within the event data.  This lets you
     // pass in a time for you to run the job:
     // await step.sleepUntil(event.data.run_at) // Assuming event.data.run_at is a timestamp.
```

### Scheduled Functions

A scheduled function now uses the logger to output success rather than a payload message.

Note that one can access Inngest's `logger` set on the client from the `event`:

```ts
  async (event) => {
     const payload = {
       message: `Scheduled ${humanizedName} function ran.`,
       runAt: Date.now().toString(),
     }
     event.logger.debug(payload, `${humanizedName} function ran.`)
   }
 )
```

### RedwoodJS

1. The `api/src/functions/inngest.ts` function has several changes:

- In the `serve` handler, instead of the `INNGEST_APP_NAME` now one passes the complete `inngest`
  client.

```ts
// Serve your Inngest functions
export const handler = serve(inngest, inngestFunctions,
```

This name is still defined in `api/src/lib/inngest.ts`:

```ts
export const INNGEST_APP_NAME = 'Redwood_Inngest'

export const inngest = new Inngest({
  /**
   * The name of this instance, most commonly the name of the application it
   * resides in.
   */
  name: INNGEST_APP_NAME,
```

2. RedwoodJS v6 canary builds may need the `serve` path to be
   `servePath: '/.redwood/functions/inngest'` instead of simply `/inngest`.

One you then start the Inngest dev server as:

```bash
npx inngest-cli@latest dev -u http://localhost:8910/.redwood/functions/inngest
```
