### PR TITLE
Fix link to README.md

### DIFF
--- a/packages/plugins/inngest/README.md
+++ b/packages/plugins/inngest/README.md
@@ -639,4 +639,4 @@ which will redact the email in the `variables` sent:
 
 ## Additional Information
 
-For more information about this plugin and Inngest, see the main [README](../../../README.md).
+For more information about this plugin and Inngest, see the main [README](https://github.com/inngest/envelop-plugin-inngest/blob/main/README.md).


### PR DESCRIPTION
Link rendered on https://the-guild.dev/graphql/envelop/plugins/use-inngest is broken. I fixed it by using an absolute path to the file.